### PR TITLE
Volume steps: Add 25th step for convenience

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -621,6 +621,7 @@
     <!-- Volume step options. -->
     <string-array name="volume_steps_entries" translatable="false">
         <item>@string/volume_steps_30</item>
+        <item>@string/volume_steps_25</item>
         <item>@string/volume_steps_15</item>
         <item>@string/volume_steps_7</item>
         <item>@string/volume_steps_5</item>
@@ -628,6 +629,7 @@
 
     <string-array name="volume_steps_values" translatable="false">
         <item>30</item>
+        <item>25</item>
         <item>15</item>
         <item>7</item>
         <item>5</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -888,6 +888,7 @@
     <string name="volume_steps_title">Volume steps</string>
     <string name="volume_steps_summary">Configure available steps for different audio volumes</string>
     <string name="volume_steps_30">30 steps</string>
+    <string name="volume_steps_25">25 steps</string>
     <string name="volume_steps_15">15 steps</string>
     <string name="volume_steps_7">7 steps</string>
     <string name="volume_steps_5">5 steps</string>


### PR DESCRIPTION
- This is because many devices have the media volume set to 25 steps in their props

Change-Id: I2f942291fb39166f802fc071748ebacb7bfa3bff
Signed-off-by: Nick <nickgunale@gmail.com>